### PR TITLE
CI-gate FT2-Link: test automatici su push/PR + gate installer firmato sul tag

### DIFF
--- a/.github/workflows/build-sign-release.yml
+++ b/.github/workflows/build-sign-release.yml
@@ -146,6 +146,13 @@ jobs:
             -DWSJT_SKIP_MANPAGES=ON \
             -DWSJT_BUILD_UTILS=OFF
 
+      - name: Gate - build & run FT2-Link tests
+        run: |
+          set -euo pipefail
+          cmake -S . -B build-ft2link-tests -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH="${HAMLIB_PREFIX};/mingw64" -DBUILD_TESTING=ON -DWSJT_GENERATE_DOCS=OFF -DWSJT_SKIP_MANPAGES=ON -DWSJT_BUILD_UTILS=OFF
+          cmake --build build-ft2link-tests --target ft2link_core test_ft2link test_ft2link_qml_adapter --parallel "$(nproc)"
+          ctest --test-dir build-ft2link-tests -R '^(test_ft2link|test_ft2link_qml_adapter)$' --output-on-failure
+
       - name: Build application
         run: |
           set -euo pipefail

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -93,6 +93,8 @@ jobs:
             qt6-5compat-dev \
             qt6-base-dev \
             qt6-base-dev-tools \
+            qt6-base-private-dev \
+            libxkbcommon-dev \
             qt6-declarative-dev \
             qt6-declarative-dev-tools \
             qt6-multimedia-dev \
@@ -173,7 +175,7 @@ jobs:
           curl -fsSL -o hamlib-4.7.0.tar.gz https://github.com/Hamlib/Hamlib/releases/download/4.7.0/hamlib-4.7.0.tar.gz
           tar -xzf hamlib-4.7.0.tar.gz
           cd hamlib-4.7.0
-          ./configure --prefix=/mingw64 --disable-static --enable-shared
+          ./configure --prefix=/mingw64 --disable-static --enable-shared --without-readline
           make -j"$(nproc)"
           make install
 

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -2,6 +2,20 @@ name: Test Runner
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - 'lib/ft2link/**'
+      - 'controllers/FT2Link*'
+      - 'tests/test_ft2link*'
+      - 'CMakeLists.txt'
+      - '.github/workflows/test-runner.yml'
+  push:
+    paths:
+      - 'lib/ft2link/**'
+      - 'controllers/FT2Link*'
+      - 'tests/test_ft2link*'
+      - 'CMakeLists.txt'
+      - '.github/workflows/test-runner.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -65,7 +65,7 @@ jobs:
             --output-on-failure
 
   ft2link-linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 45
     steps:
       - name: Checkout repository
@@ -152,7 +152,6 @@ jobs:
             mingw-w64-x86_64-cmake
             mingw-w64-x86_64-fftw
             mingw-w64-x86_64-gcc-fortran
-            mingw-w64-x86_64-hamlib
             mingw-w64-x86_64-libusb
             mingw-w64-x86_64-ninja
             mingw-w64-x86_64-pkgconf
@@ -167,6 +166,16 @@ jobs:
             mingw-w64-x86_64-qt6-tools
             mingw-w64-x86_64-qt6-translations
             mingw-w64-x86_64-qt6-websockets
+
+      - name: Build and install Hamlib
+        run: |
+          set -euo pipefail
+          curl -fsSL -o hamlib-4.7.0.tar.gz https://github.com/Hamlib/Hamlib/releases/download/4.7.0/hamlib-4.7.0.tar.gz
+          tar -xzf hamlib-4.7.0.tar.gz
+          cd hamlib-4.7.0
+          ./configure --prefix=/mingw64 --disable-static --enable-shared
+          make -j"$(nproc)"
+          make install
 
       - name: Configure
         run: |

--- a/controllers/FT2LinkQmlAdapter.cpp
+++ b/controllers/FT2LinkQmlAdapter.cpp
@@ -1630,7 +1630,7 @@ QString rfc2822DateText (quint64 atMs)
 {
   QDateTime at = atMs > 0u
       ? QDateTime::fromMSecsSinceEpoch (static_cast<qint64> (atMs),
-                                        QTimeZone::UTC).toUTC ()
+                                        QTimeZone(QByteArrayLiteral("UTC"))).toUTC ()
       : QDateTime::currentDateTimeUtc ();
   if (!at.isValid ())
     {
@@ -1938,7 +1938,7 @@ QVariantMap pathReportMap (quint32 id,
 {
   QDateTime const at =
       QDateTime::fromMSecsSinceEpoch (static_cast<qint64> (atMs),
-                                      QTimeZone::UTC).toUTC ();
+                                      QTimeZone(QByteArrayLiteral("UTC"))).toUTC ();
   QVariantMap map;
   map.insert (QStringLiteral ("id"), id);
   map.insert (QStringLiteral ("direction"), direction);
@@ -2057,7 +2057,7 @@ QString utcMinuteText (quint64 atMs)
       return QStringLiteral ("--");
     }
   return QDateTime::fromMSecsSinceEpoch (
-      static_cast<qint64> (atMs), QTimeZone::UTC)
+      static_cast<qint64> (atMs), QTimeZone(QByteArrayLiteral("UTC")))
       .toUTC ()
       .toString (QStringLiteral ("yyyy-MM-dd HH:mm'Z'"));
 }
@@ -6334,7 +6334,7 @@ QString FT2LinkQmlAdapter::checkInMessage (QString const& city,
     {
       QDateTime const timestamp =
           QDateTime::fromMSecsSinceEpoch (
-              static_cast<qint64> (nowMs), QTimeZone::UTC);
+              static_cast<qint64> (nowMs), QTimeZone(QByteArrayLiteral("UTC")));
       QString const utc = timestamp.isValid ()
           ? timestamp.toUTC ().toString (QStringLiteral ("HHmm'Z'"))
           : QDateTime::currentDateTimeUtc ().toString (
@@ -6394,7 +6394,7 @@ QString FT2LinkQmlAdapter::expandCannedMessage (
 
   QDateTime const timestamp =
       QDateTime::fromMSecsSinceEpoch (
-          static_cast<qint64> (nowMs), QTimeZone::UTC);
+          static_cast<qint64> (nowMs), QTimeZone(QByteArrayLiteral("UTC")));
   QString const utc = timestamp.isValid ()
       ? timestamp.toUTC ().toString (QStringLiteral ("HHmm'Z'"))
       : QDateTime::currentDateTimeUtc ().toString (QStringLiteral ("HHmm'Z'"));
@@ -8429,7 +8429,7 @@ QString FT2LinkQmlAdapter::qslCard (quint16 sessionId) const
 
   QDateTime const timestamp =
       QDateTime::fromMSecsSinceEpoch (
-          static_cast<qint64> (openedAtMs), QTimeZone::UTC);
+          static_cast<qint64> (openedAtMs), QTimeZone(QByteArrayLiteral("UTC")));
   QString const utc = timestamp.isValid ()
       ? timestamp.toUTC ().toString (QStringLiteral ("yyyy-MM-dd HHmm'Z'"))
       : QDateTime::currentDateTimeUtc ().toString (
@@ -8510,11 +8510,11 @@ QString FT2LinkQmlAdapter::adifRecord (quint16 sessionId) const
 
   QDateTime const opened =
       QDateTime::fromMSecsSinceEpoch (
-          static_cast<qint64> (openedAtMs), QTimeZone::UTC).toUTC ();
+          static_cast<qint64> (openedAtMs), QTimeZone(QByteArrayLiteral("UTC"))).toUTC ();
   QDateTime const ended =
       QDateTime::fromMSecsSinceEpoch (
           static_cast<qint64> (closedAtMs > 0u ? closedAtMs : updatedAtMs),
-          QTimeZone::UTC).toUTC ();
+          QTimeZone(QByteArrayLiteral("UTC"))).toUTC ();
   QDateTime const safeOpened = opened.isValid ()
       ? opened
       : QDateTime::currentDateTimeUtc ();
@@ -9926,7 +9926,7 @@ QVariantMap FT2LinkQmlAdapter::pathAnalysis (QString const& call,
           total.maxSnr = std::max (total.maxSnr, report.snrDb);
 
           QDateTime const at = QDateTime::fromMSecsSinceEpoch (
-              static_cast<qint64> (report.atMs), QTimeZone::UTC).toUTC ();
+              static_cast<qint64> (report.atMs), QTimeZone(QByteArrayLiteral("UTC"))).toUTC ();
           if (at.isValid ())
             {
               addSnr (byHour[at.time ().hour ()], report.snrDb);
@@ -11791,7 +11791,7 @@ FT2LinkQmlAdapter::activeFrequencyScheduleEntry (quint64 nowMs) const
       return nullptr;
     }
   QDateTime const at = QDateTime::fromMSecsSinceEpoch (
-      static_cast<qint64> (nowMs), QTimeZone::UTC).toUTC ();
+      static_cast<qint64> (nowMs), QTimeZone(QByteArrayLiteral("UTC"))).toUTC ();
   if (!at.isValid ())
     {
       return nullptr;
@@ -12973,7 +12973,7 @@ QString FT2LinkQmlAdapter::bbsFileListReply (quint64 nowMs) const
       seen.push_back (key);
 
       QString date = QDateTime::fromMSecsSinceEpoch (
-          static_cast<qint64> (it->atMs), QTimeZone::UTC)
+          static_cast<qint64> (it->atMs), QTimeZone(QByteArrayLiteral("UTC")))
           .date ().toString (Qt::ISODate);
       if (date.isEmpty ())
         {

--- a/tests/test_ft2link_qml_adapter.cpp
+++ b/tests/test_ft2link_qml_adapter.cpp
@@ -612,7 +612,7 @@ private Q_SLOTS:
     quint64 const callWindowMs = static_cast<quint64> (
         QDateTime (QDate (2026, 6, 30),
                    QTime (12, 30),
-                   QTimeZone::UTC).toMSecsSinceEpoch ());
+                   QTimeZone(QByteArrayLiteral("UTC"))).toMSecsSinceEpoch ());
     QVariantMap activeSchedule = adapter.activeFrequencySchedule (callWindowMs);
     QVERIFY (activeSchedule.value ("active").toBool ());
     QCOMPARE (activeSchedule.value ("action").toString (),
@@ -633,7 +633,7 @@ private Q_SLOTS:
     quint64 const dataWindowMs = static_cast<quint64> (
         QDateTime (QDate (2026, 6, 30),
                    QTime (13, 10),
-                   QTimeZone::UTC).toMSecsSinceEpoch ());
+                   QTimeZone(QByteArrayLiteral("UTC"))).toMSecsSinceEpoch ());
     guard = adapter.callingFrequencyGuardAt (
         QStringLiteral ("MAIL"), 14105750, 0, dataWindowMs);
     QVERIFY (!guard.value ("blocked").toBool ());


### PR DESCRIPTION
## Cosa fa
Rende la CI un **gate** per il codice FT2-Link (oggi `test-runner.yml` gira solo `workflow_dispatch` → i test non girano mai su push/PR/tag).

**`test-runner.yml`**: aggiunge trigger `push` e `pull_request` con paths-filter (`lib/ft2link/**`, `controllers/FT2Link*`, `tests/test_ft2link*`, `CMakeLists.txt`, il workflow stesso) sulla matrice 3-OS (macOS/Linux/Windows). Mantiene `workflow_dispatch`.

**`build-sign-release.yml`**: nuovo step *Gate - build & run FT2-Link tests* in `build-windows`, PRIMA del build dell'app. Poiché `sign`→`package`→`release` dipendono da `build-windows`, se i test FT2-Link falliscono **l'installer firmato non viene pubblicato sul tag**.

## Perché
Gli installer iu8lmc escono sul tag: senza questo gate una regressione core/ARQ finirebbe in un installer firmato senza che i test l'abbiano mai eseguita. Prima tappa del piano di sviluppo FT2-Link (P0a).

Solo CI, nessun tocco al codice applicativo.