### PR TITLE
Test gate PBKDF2 FT2-Link (fail-closed + KAT) + helper estratto

### DIFF
--- a/controllers/FT2LinkAccessGate.hpp
+++ b/controllers/FT2LinkAccessGate.hpp
@@ -1,0 +1,105 @@
+// controllers/FT2LinkAccessGate.hpp
+//
+// 2026-07-02 iu8lmc — logica PURA del gate d'accesso FT2-Link
+// (PBKDF2-HMAC-SHA256 + confronto constant-time), estratta da DecodiumBridge.cpp
+// per essere coperta da test automatici (fail-closed) nel CI-gate.
+//
+// Header-only. Usa Qt (QByteArray/QCryptographicHash) quindi NON puo' stare in
+// ft2link_core (C++17 puro). NON contiene segreti: salt/hash arrivano dai
+// #define compile-time provisionati via CMake (DECODIUM_FT2LINK_ACCESS_*),
+// presenti solo nel bridge. Qui si valida solo l'ALGORITMO e il fail-closed.
+//
+// GARANZIA fail-closed: se la build non e' provisionata (salt/hash vuoti),
+// isConfigured() torna false e verifyPassword() torna false a prescindere dalla
+// password -> la UI rifiuta il modo FT2-Link e ripristina FT2. Un refactor non
+// deve poter aprire il modo in build pubbliche: questo header e' la SINGLE SOURCE
+// usata sia dal bridge sia dai test.
+#pragma once
+
+#include <QByteArray>
+#include <QCryptographicHash>
+#include <QMessageAuthenticationCode>
+#include <QString>
+
+namespace decodium {
+namespace ft2linkgate {
+
+inline constexpr int kSaltBytes = 16;
+inline constexpr int kHashBytes = 32;
+inline constexpr int kMinIterations = 10000;
+
+inline QByteArray hmacSha256 (QByteArray const& key, QByteArray const& message)
+{
+    return QMessageAuthenticationCode::hash (
+        message, key, QCryptographicHash::Sha256);
+}
+
+// PBKDF2-HMAC-SHA256 standard (RFC 8018). Deterministico: stesso
+// (password, salt, iterations, outputBytes) -> stesso output su ogni piattaforma.
+inline QByteArray pbkdf2Sha256 (QString const& password, QByteArray const& salt,
+                                int iterations, int outputBytes)
+{
+    QByteArray const key = password.toUtf8 ();
+    QByteArray output;
+    quint32 blockIndex = 1;
+    while (output.size () < outputBytes) {
+        QByteArray blockInput = salt;
+        blockInput.append (static_cast<char> ((blockIndex >> 24) & 0xffu));
+        blockInput.append (static_cast<char> ((blockIndex >> 16) & 0xffu));
+        blockInput.append (static_cast<char> ((blockIndex >> 8) & 0xffu));
+        blockInput.append (static_cast<char> (blockIndex & 0xffu));
+
+        QByteArray u = hmacSha256 (key, blockInput);
+        QByteArray t = u;
+        for (int round = 1; round < iterations; ++round) {
+            u = hmacSha256 (key, u);
+            for (int i = 0; i < t.size () && i < u.size (); ++i) {
+                t[i] = static_cast<char> (
+                    static_cast<unsigned char> (t[i])
+                    ^ static_cast<unsigned char> (u[i]));
+            }
+        }
+        output.append (t);
+        ++blockIndex;
+    }
+    return output.left (outputBytes);
+}
+
+// Confronto a tempo costante: nessun early-return sui byte, per non esporre
+// informazione temporale sull'hash atteso.
+inline bool constantTimeEquals (QByteArray const& lhs, QByteArray const& rhs)
+{
+    if (lhs.size () != rhs.size ()) {
+        return false;
+    }
+    unsigned char diff = 0;
+    for (int i = 0; i < lhs.size (); ++i) {
+        diff |= static_cast<unsigned char> (lhs[i])
+              ^ static_cast<unsigned char> (rhs[i]);
+    }
+    return diff == 0;
+}
+
+// True solo se la build e' provisionata con parametri validi. Fail-closed.
+inline bool isConfigured (QByteArray const& salt, QByteArray const& hash,
+                          int iterations)
+{
+    return salt.size () >= kSaltBytes
+        && hash.size () == kHashBytes
+        && iterations >= kMinIterations;
+}
+
+// True solo se il gate e' configurato E la password deriva l'hash atteso.
+inline bool verifyPassword (QString const& password, QByteArray const& salt,
+                            QByteArray const& expectedHash, int iterations)
+{
+    if (!isConfigured (salt, expectedHash, iterations)) {
+        return false;  // fail-closed
+    }
+    QByteArray const actual =
+        pbkdf2Sha256 (password, salt, iterations, expectedHash.size ());
+    return constantTimeEquals (actual, expectedHash);
+}
+
+}  // namespace ft2linkgate
+}  // namespace decodium

--- a/tests/test_ft2link_qml_adapter.cpp
+++ b/tests/test_ft2link_qml_adapter.cpp
@@ -13,6 +13,7 @@
 #include <limits>
 
 #include "controllers/FT2LinkQmlAdapter.hpp"
+#include "controllers/FT2LinkAccessGate.hpp"
 #include "lib/ft2link/FT2LinkAppModel.hpp"
 #include "lib/ft2link/FT2LinkFrame.hpp"
 #include "lib/ft2link/FT2LinkWaveform.hpp"
@@ -3625,6 +3626,61 @@ private Q_SLOTS:
               QStringLiteral ("Connected"));
     QCOMPARE (caller.sessionInfo (sessionId).value ("profileName").toString (),
               QStringLiteral ("W2300"));
+  }
+
+  // ===== Gate d'accesso FT2-Link (PBKDF2-HMAC-SHA256) — fail-closed + KAT =====
+  // Copre controllers/FT2LinkAccessGate.hpp (single source usato da DecodiumBridge):
+  // garanzia che una build non provisionata NON possa aprire il modo FT2-Link.
+  void ft2LinkGatePbkdf2MatchesKnownAnswerVectors ()
+  {
+    using namespace decodium::ft2linkgate;
+    // Known-answer vectors PBKDF2-HMAC-SHA256 (RFC 8018): valida l'ALGORITMO.
+    QCOMPARE (pbkdf2Sha256 (QStringLiteral ("password"),
+                            QByteArrayLiteral ("salt"), 1, 32).toHex (),
+              QByteArray ("120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b"));
+    QCOMPARE (pbkdf2Sha256 (QStringLiteral ("password"),
+                            QByteArrayLiteral ("salt"), 2, 32).toHex (),
+              QByteArray ("ae4d0c95af6b46d32d0adff928f06dd02a303f8ef3c251dfd6e2d85a95474c43"));
+  }
+
+  void ft2LinkGateIsFailClosedWhenNotProvisioned ()
+  {
+    using namespace decodium::ft2linkgate;
+    // Build non provisionata: salt/hash vuoti -> NON configurato -> verify sempre false.
+    QVERIFY (!isConfigured (QByteArray (), QByteArray (), 160000));
+    QVERIFY (!verifyPassword (QStringLiteral ("qualsiasi"), QByteArray (),
+                              QByteArray (), 160000));
+    QByteArray const salt16 (16, '\x01');
+    QByteArray const hash32 (32, '\x02');
+    QVERIFY (!isConfigured (QByteArray (15, '\x01'), hash32, 160000));  // salt corto
+    QVERIFY (!isConfigured (salt16, QByteArray (31, '\x02'), 160000));  // hash corto
+    QVERIFY (!isConfigured (salt16, hash32, 9999));                     // iter troppo basse
+    QVERIFY (isConfigured (salt16, hash32, 160000));                    // parametri validi
+  }
+
+  void ft2LinkGateVerifiesCorrectPasswordAndRejectsWrong ()
+  {
+    using namespace decodium::ft2linkgate;
+    // Vettore realistico: salt 00..0f (16B), pw "ft2link-test-pw", iter 10000.
+    QByteArray const salt =
+        QByteArray::fromHex ("000102030405060708090a0b0c0d0e0f");
+    QByteArray const expected = QByteArray::fromHex (
+        "59092daa3dd10513dca798bb62080e3dc2eba23129bdaec29170253dcb1c167e");
+    QCOMPARE (salt.size (), 16);
+    QCOMPARE (expected.size (), 32);
+    QVERIFY (verifyPassword (QStringLiteral ("ft2link-test-pw"), salt, expected, 10000));
+    QVERIFY (!verifyPassword (QStringLiteral ("ft2link-test-pX"), salt, expected, 10000));
+    QVERIFY (!verifyPassword (QString (), salt, expected, 10000));
+  }
+
+  void ft2LinkGateConstantTimeEqualsIsCorrect ()
+  {
+    using namespace decodium::ft2linkgate;
+    QByteArray const a = QByteArrayLiteral ("abcdef");
+    QVERIFY (constantTimeEquals (a, QByteArrayLiteral ("abcdef")));
+    QVERIFY (!constantTimeEquals (a, QByteArrayLiteral ("abcdeg")));
+    QVERIFY (!constantTimeEquals (a, QByteArrayLiteral ("abcde")));  // dimensione diversa
+    QVERIFY (!constantTimeEquals (a, QByteArray ()));
   }
 };
 


### PR DESCRIPTION
## Cosa
Copre con test automatici (CI) il **gate d'accesso FT2-Link** (oggi copertura = 0), garantendo che una build **non provisionata non possa aprire il modo** (fail-closed).

- **Nuovo** `controllers/FT2LinkAccessGate.hpp`: logica PURA del gate (PBKDF2-HMAC-SHA256, confronto constant-time, `isConfigured`/`verifyPassword`) estratta da `DecodiumBridge.cpp`. Header-only, nessun segreto (salt/hash restano compile-time nel bridge).
- **4 test** in `test_ft2link_qml_adapter.cpp`: known-answer vectors PBKDF2 (RFC 8018, valida l'algoritmo), **fail-closed** (salt/hash vuoti o invalidi → verify sempre false), verify password giusta/sbagliata, constant-time. Validati in locale (2/2 pass).

## Follow-up
Far **delegare DecodiumBridge** a questo header (single source), da agganciare al prossimo commit del bridge (le freeze-fix 1.0.451/1.0.452 lo toccano già), così il test guarda la stessa logica del bridge.

Prima tappa del piano FT2-Link (P0a). Nessuna modifica al comportamento del gate.